### PR TITLE
Stop logging serial input, to avoid circularity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odyssey"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -59,7 +59,7 @@ impl Gcode {
                 },
                 Ok(n) => {
                     if n>0 {
-                        println!("Read {} bytes from serial: {}", n, read_string.trim_end());
+                        //println!("Read {} bytes from serial: {}", n, read_string.trim_end());
                         sender.send(read_string).await.expect("Unable to send message to channel");
                     }
                 },


### PR DESCRIPTION
All of the `println!` statements should eventually be converted to an actual logging library, with log levels set in config, but that's a tomorrow problem.