### PR TITLE
Fix Poem Address Bind & Move Example Config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
         id: compress
         run: |
           cp target/armv7-unknown-linux-gnueabihf/release/odyssey odyssey
-          cp target/armv7-unknown-linux-gnueabihf/release/odyssey.yaml odyssey.yaml
+          cp target/armv7-unknown-linux-gnueabihf/release/default.yaml default.yaml
           cp target/armv7-unknown-linux-gnueabihf/release/apiHelper.py apiHelper.py
-          tar -czvf odyssey.tar.gz odyssey odyssey.yaml apiHelper.py
+          tar -czvf odyssey.tar.gz odyssey default.yaml apiHelper.py
           echo "archive=$ARCHIVE" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v4.3.1
@@ -44,7 +44,7 @@ jobs:
           name: odyssey
           path: |
             odyssey
-            odyssey.yaml
+            default.yaml
             apiHelper.py
 
       - uses: ncipollo/release-action@v1.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odyssey"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs;
 use std::path::Path;
 
-const CONFIG_FILE: &str = "odyssey.yaml";
+const CONFIG_FILE: &str = "default.yaml";
 const API_HELPER_FILE: &str = "apiHelper.py";
 
 fn main() {

--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,48 @@
+# This is the default Odyssey configuration file for the Prometheus MSLA. It is
+# meant to be paired with the latest Prometheus MSLA klipper config.
+
+# This section holds the config fields related to the printer, such as its serial
+# connection and its frame buffer specs
+printer:
+  serial: /home/pi/printer_data/comms/klippy.serial
+  baudrate: 250000
+  frame_buffer: /dev/fb0
+  fb_bit_depth: 5
+  fb_chunk_size: 16
+  max_z: 350
+  default_lift: 10
+  default_up_speed: 3.4
+  default_down_speed: 3.4
+  default_wait_before_exposure: 2.2
+  default_wait_after_exposure: 1.5
+
+# This section holds fields pertaining to the Gcode used to drive the machine's
+# hardware, and signal between the board and Odyssey
+gcode:
+  boot: |
+    G90
+  shutdown: |
+    M84
+    UVLED_OFF
+  home_command: G28
+  move_command: MOVE_PLATE Z={z} F={speed}
+  print_start: |
+    HOME_AXIS
+    SET_PRINT_STATS_INFO TOTAL_LAYER={total_layers}
+  print_end: |
+    MOVE_PLATE Z={max_z} F=400
+  layer_start: SET_PRINT_STATS_INFO CURRENT_LAYER={layer}
+  cure_start: UVLED_ON
+  cure_end: UVLED_OFF
+  move_sync: Z_move_comp
+  move_timeout: 60
+  status_check: status
+  status_desired: "Klipper state: Ready"
+
+# This section holds fields pertaining to the Odyseey API, such as the port number
+# and where to store uploaded .sl1 files
+api:
+  upload_path: /home/pi/printer_data/gcodes
+  # glob pattern for finding files in mounted USB devices, if present
+  usb_glob: /media/usb*/*.sl1
+  port: 12357

--- a/src/api.rs
+++ b/src/api.rs
@@ -340,7 +340,7 @@ pub async fn start_api(configuration: ApiConfig, operation_sender: mpsc::Sender<
         ;//.catch_error(f);
 
     let port = configuration.port.to_string();
-    let addr = format!("127.0.0.1:{port}");
+    let addr = format!("0.0.0.0:{port}");
 
     Server::new(TcpListener::bind(addr))
         .run(app)

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod printfile;
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Odyssey config file
-    #[arg(default_value_t=String::from("./odyssey.yaml"), short, long)]
+    #[arg(default_value_t=String::from("./default.yaml"), short, long)]
     config: String,
     #[arg(default_value_t=String::from("DEBUG"), short, long)]
     loglevel: String

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -1,0 +1,48 @@
+# This is the default Odyssey configuration file for the Prometheus MSLA. It is
+# meant to be paired with the latest Prometheus MSLA klipper config.
+
+# This section holds the config fields related to the printer, such as its serial
+# connection and its frame buffer specs
+printer:
+  serial: /dev/pts/6 # Mock port opened with `python3 test/mockSerial.py`
+  baudrate: 250000
+  frame_buffer: /dev/null # Dump frames to null for testing
+  fb_bit_depth: 5
+  fb_chunk_size: 16
+  max_z: 350
+  default_lift: 10
+  default_up_speed: 3.4
+  default_down_speed: 3.4
+  default_wait_before_exposure: 2.2
+  default_wait_after_exposure: 1.5
+
+# This section holds fields pertaining to the Gcode used to drive the machine's
+# hardware, and signal between the board and Odyssey
+gcode:
+  boot: |
+    G90
+  shutdown: |
+    M84
+    UVLED_OFF
+  home_command: G28
+  move_command: MOVE_PLATE Z={z} F={speed}
+  print_start: |
+    HOME_AXIS
+    SET_PRINT_STATS_INFO TOTAL_LAYER={total_layers}
+  print_end: |
+    MOVE_PLATE Z={max_z} F=400
+  layer_start: SET_PRINT_STATS_INFO CURRENT_LAYER={layer}
+  cure_start: UVLED_ON
+  cure_end: UVLED_OFF
+  move_sync: Z_move_comp
+  move_timeout: 60
+  status_check: status
+  status_desired: "Klipper state: Ready"
+
+# This section holds fields pertaining to the Odyseey API, such as the port number
+# and where to store uploaded .sl1 files
+api:
+  upload_path: /home/pi/printer_data/gcodes
+  # glob pattern for finding files in mounted USB devices, if present
+  usb_glob: /media/usb*/*.sl1
+  port: 12357


### PR DESCRIPTION
Fix poem to bind on all network devices instead of just localhost Move odyssey.yaml to example.yaml, to pair with an odyssey.yaml in the prometheus config repo
Add test.yaml for testing