### PR TITLE
api: GET /files includes dirs, GET metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Update Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          rustflags: ""
+          rustflags: "-Awarning"
 
       - name: Compile, Copy, and Compress armv7
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.1.6", features = ["derive"] }
 cross = "0.2.5"
-config = "0.14.0"
+config = "0.13.4"
 serde = "1.0"
 serde_yaml = "0.9"
 zip = "1.1.1"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,7 @@
 use std::{
     ffi::OsStr,
-    fs::{DirEntry, File},
+    fs::File,
     io::{Read, Write},
-    iter,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, UNIX_EPOCH},

--- a/src/api.rs
+++ b/src/api.rs
@@ -270,7 +270,7 @@ fn _get_usb_files(
 
 fn get_file_path(
     configuration: &ApiConfig,
-    file_path: &String,
+    file_path: &str,
     location: &LocationCategory,
 ) -> Result<PathBuf, NotFoundError> {
     log::info!("Getting full file path {:?}, {:?}", location, file_path);
@@ -284,13 +284,13 @@ fn get_file_path(
 // Since USB paths are specified as a glob, find all and filter to file_name
 fn get_usb_file_path(
     configuration: &ApiConfig,
-    file_name: &String,
+    file_name: &str,
 ) -> Result<PathBuf, NotFoundError> {
     let paths = glob(&configuration.usb_glob).map_err(|_| NotFoundError)?;
 
     let path_buf = paths
         .filter_map(|path| path.ok())
-        .find(|path| path.ends_with(file_name.clone()))
+        .find(|path| path.ends_with(file_name))
         .ok_or_else(|| {
             log::error!("Unable to read USB file");
             NotFoundError
@@ -302,7 +302,7 @@ fn get_usb_file_path(
 // For Local files, look directly for specific file
 fn get_local_file_path(
     configuration: &ApiConfig,
-    file_path: &String,
+    file_path: &str,
 ) -> Result<PathBuf, NotFoundError> {
     let path = Path::new(&configuration.upload_path).join(file_path);
 
@@ -339,8 +339,7 @@ fn _get_filedata(
             })?,
         name: target_file
             .file_name()
-            .map(|path_str| path_str.to_str())
-            .flatten()
+            .and_then(|path_str| path_str.to_str())
             .map(|path_str| path_str.to_string())
             .ok_or_else(|| {
                 log::error!("Error converting file name");

--- a/src/printfile.rs
+++ b/src/printfile.rs
@@ -13,6 +13,7 @@ pub struct FileData {
     pub name: String,
     pub last_modified: Option<u128>,
     pub location_category: LocationCategory,
+    pub parent_path: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/sl1.rs
+++ b/src/sl1.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Read};
+use std::{fs::File, io::Read, path::Path};
 
 use async_trait::async_trait;
 use config::{Config, ConfigError, File as ConfigFile, FileFormat};
@@ -70,7 +70,10 @@ impl PrintFile for Sl1 {
     /// Instantiate the Sl1 from the given file
     fn from_file(file_data: FileData) -> Sl1 {
         log::info!("Loading PrintFile from SL1 {:?}", file_data);
-        let file = File::open(file_data.path.clone()).unwrap();
+
+        let full_path = Path::new(file_data.parent_path.as_str()).join(file_data.path.as_str());
+
+        let file = File::open(full_path).unwrap();
 
         let mut archive = ZipArchive::new(file).unwrap();
 


### PR DESCRIPTION
Modify GET single file endpoint to use :file_path instead of :file_name
Modify /print/start to use :file_path instead of :file_name Modify GET /files response to also return directory vec, allowing the UI to hit one endpoint for filescreen population and eventual sorting/filtering
Add GET /files/:location/:file_path/metadata endpoint for getting metadata for a single file