### PR TITLE
printer: store distances internally as microns

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -144,7 +144,9 @@ impl Api {
     ) -> Result<()> {
         if let Query(Some(z)) = z {
             operation_sender
-                .send(Operation::ManualMove { z: (z * 1000.0).trunc() as u32 })
+                .send(Operation::ManualMove {
+                    z: (z * 1000.0).trunc() as u32,
+                })
                 .await
                 .map_err(ServiceUnavailable)?;
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -137,14 +137,14 @@ impl Api {
     #[oai(path = "/manual", method = "post")]
     async fn manual_control(
         &self,
-        z: Query<Option<f32>>,
+        z: Query<Option<f64>>,
         cure: Query<Option<bool>>,
         Data(operation_sender): Data<&mpsc::Sender<Operation>>,
         Data(_state_ref): Data<&Arc<RwLock<PrinterState>>>,
     ) -> Result<()> {
         if let Query(Some(z)) = z {
             operation_sender
-                .send(Operation::ManualMove { z })
+                .send(Operation::ManualMove { z: (z * 1000.0).trunc() as u32 })
                 .await
                 .map_err(ServiceUnavailable)?;
         }
@@ -524,6 +524,7 @@ pub async fn start_api(
         layer: None,
         physical_state: PhysicalState {
             z: 0.0,
+            z_microns: 0,
             curing: false,
         },
         status: PrinterStatus::Shutdown,

--- a/src/api_objects.rs
+++ b/src/api_objects.rs
@@ -26,15 +26,17 @@ pub struct FileMetadata {
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]
 pub struct PrintMetadata {
     pub file_data: FileMetadata,
-    pub used_material: f32,
-    pub print_time: f32,
-    pub layer_height: f32,
+    pub used_material: f64,
+    pub print_time: f64,
+    pub layer_height: f64,
+    pub layer_height_microns: u32,
     pub layer_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Object)]
 pub struct PhysicalState {
-    pub z: f32,
+    pub z: f64,
+    pub z_microns: u32,
     pub curing: bool,
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -9,12 +9,12 @@ pub struct PrinterConfig {
     pub frame_buffer: String,
     pub fb_bit_depth: u8,
     pub fb_chunk_size: u8,
-    pub max_z: f32,
-    pub default_lift: f32,
-    pub default_up_speed: f32,
-    pub default_down_speed: f32,
-    pub default_wait_before_exposure: f32,
-    pub default_wait_after_exposure: f32,
+    pub max_z: f64,
+    pub default_lift: f64,
+    pub default_up_speed: f64,
+    pub default_down_speed: f64,
+    pub default_wait_before_exposure: f64,
+    pub default_wait_after_exposure: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,12 +5,12 @@ use png::Decoder;
 pub struct Frame {
     pub file_name: String,
     pub buffer: Vec<u8>,
-    pub exposure_time: f32,
+    pub exposure_time: f64,
     pub bit_depth: u8,
 }
 
 impl Frame {
-    pub fn from_vec(name: String, exposure_time: f32, data: Vec<u8>) -> Frame {
+    pub fn from_vec(name: String, exposure_time: f64, data: Vec<u8>) -> Frame {
         let decoder = Decoder::new(data.as_slice());
 
         let mut png_reader = decoder.read_info().expect("Unable to read PNG metadata");

--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -36,6 +36,7 @@ impl Gcode {
             config: config.gcode,
             state: PhysicalState {
                 z: 0.0,
+                z_microns: 0,
                 curing: false,
             },
             gcode_substitutions: HashMap::new(),
@@ -164,8 +165,9 @@ impl Gcode {
     /// Set the internally-stored position. Any method which uses a send_gcode
     /// method to cause the z axis to move, should call this method to reflect
     /// that change
-    fn set_position(&mut self, position: f32) -> PhysicalState {
-        self.state.z = position;
+    fn set_position(&mut self, position: u32) -> PhysicalState {
+        self.state.z_microns = position;
+        self.state.z = (position as f64) / 1000.0;
         self.state
     }
 
@@ -217,10 +219,7 @@ impl HardwareControl for Gcode {
         Ok(self.state)
     }
 
-    async fn move_z(&mut self, z: f32, speed: f32) -> std::io::Result<PhysicalState> {
-        // To handle floating point precision issues, truncate to micron precision
-        let z = (z * 1000.0).trunc() / 1000.0;
-
+    async fn move_z(&mut self, z: u32, speed: f64) -> std::io::Result<PhysicalState> {
         // Convert from mm/s to mm/min f value
         let speed = speed * 60.0;
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -38,6 +38,7 @@ impl<T: HardwareControl> Printer<T> {
                 layer: None,
                 physical_state: PhysicalState {
                     z: 0.0,
+                    z_microns: 0,
                     curing: false,
                 },
                 status: PrinterStatus::Shutdown,
@@ -54,7 +55,7 @@ impl<T: HardwareControl> Printer<T> {
         let layer_height = file.get_layer_height();
 
         // Get movement values from file, or configured defaults
-        let lift = file.get_lift().unwrap_or(self.config.default_lift);
+        let lift = file.get_lift().unwrap_or((self.config.default_lift * 1000.0).trunc() as u32);
         let up_speed = file.get_up_speed().unwrap_or(self.config.default_up_speed);
         let down_speed = file
             .get_down_speed()
@@ -138,16 +139,16 @@ impl<T: HardwareControl> Printer<T> {
         &mut self,
         cur_frame: Frame,
         layer: usize,
-        layer_height: f32,
-        lift: f32,
-        up_speed: f32,
-        down_speed: f32,
-        wait_before_exposure: f32,
-        wait_after_exposure: f32,
+        layer_height: u32,
+        lift: u32,
+        up_speed: f64,
+        down_speed: f64,
+        wait_before_exposure: f64,
+        wait_after_exposure: f64,
     ) {
         log::info!("Begin layer {}", layer);
         self.wrapped_start_layer(layer).await;
-        let layer_z = ((layer + 1) as f32) * layer_height;
+        let layer_z = ((layer + 1) as u32) * layer_height;
         //let lift_z = layer_z+
 
         let exposure_time = cur_frame.exposure_time;
@@ -160,7 +161,7 @@ impl<T: HardwareControl> Printer<T> {
 
         // Wait for configured time before curing
         log::info!("Waiting for {}s before cure", wait_before_exposure);
-        sleep(Duration::from_secs_f32(wait_before_exposure)).await;
+        sleep(Duration::from_secs_f64(wait_before_exposure)).await;
 
         // Display the current frame to the LCD
         log::info!("Loading layer to display");
@@ -169,12 +170,12 @@ impl<T: HardwareControl> Printer<T> {
         // Activate the UV array for the prescribed length of time
         log::info!("Curing layer for {}s", exposure_time);
         self.wrapped_start_cure().await;
-        sleep(Duration::from_secs_f32(exposure_time)).await;
+        sleep(Duration::from_secs_f64(exposure_time)).await;
         self.wrapped_stop_cure().await;
 
         // Wait for configured time after curing
         log::info!("Waiting for {}s after cure", wait_after_exposure);
-        sleep(Duration::from_secs_f32(wait_after_exposure)).await;
+        sleep(Duration::from_secs_f64(wait_after_exposure)).await;
     }
 
     async fn wrapped_start_print(&mut self) {
@@ -212,7 +213,7 @@ impl<T: HardwareControl> Printer<T> {
     }
 
     // Move and update printer state
-    async fn wrapped_move(&mut self, z: f32, speed: f32) {
+    async fn wrapped_move(&mut self, z: u32, speed: f64) {
         if let Ok(physical_state) = self.hardware_controller.move_z(z, speed).await {
             self.update_physical_state(physical_state).await;
         } else {
@@ -386,7 +387,8 @@ impl<T: HardwareControl> Printer<T> {
         self.state.paused = None;
         self.state.print_data = None;
         self.state.physical_state = PhysicalState {
-            z: f32::MAX,
+            z: f64::MAX,
+            z_microns: u32::MAX,
             curing: false,
         }
     }
@@ -524,7 +526,7 @@ pub enum Operation {
     StopPrint,
     PausePrint,
     ResumePrint,
-    ManualMove { z: f32 },
+    ManualMove { z: u32 },
     ManualCure { cure: bool },
     ManualHome,
     ManualCommand { command: String },
@@ -541,7 +543,7 @@ pub trait HardwareControl {
     async fn manual_command(&mut self, command: String) -> std::io::Result<PhysicalState>;
     async fn start_print(&mut self) -> std::io::Result<PhysicalState>;
     async fn end_print(&mut self) -> std::io::Result<PhysicalState>;
-    async fn move_z(&mut self, z: f32, speed: f32) -> std::io::Result<PhysicalState>;
+    async fn move_z(&mut self, z: u32, speed: f64) -> std::io::Result<PhysicalState>;
     async fn start_layer(&mut self, layer: usize) -> std::io::Result<PhysicalState>;
     async fn start_curing(&mut self) -> std::io::Result<PhysicalState>;
     async fn stop_curing(&mut self) -> std::io::Result<PhysicalState>;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -55,7 +55,9 @@ impl<T: HardwareControl> Printer<T> {
         let layer_height = file.get_layer_height();
 
         // Get movement values from file, or configured defaults
-        let lift = file.get_lift().unwrap_or((self.config.default_lift * 1000.0).trunc() as u32);
+        let lift = file
+            .get_lift()
+            .unwrap_or((self.config.default_lift * 1000.0).trunc() as u32);
         let up_speed = file.get_up_speed().unwrap_or(self.config.default_up_speed);
         let down_speed = file
             .get_down_speed()

--- a/src/printfile.rs
+++ b/src/printfile.rs
@@ -9,7 +9,7 @@ use crate::api_objects::{FileData, FileMetadata, PrintMetadata};
 pub struct Layer {
     pub file_name: String,
     pub data: Vec<u8>,
-    pub exposure_time: f32,
+    pub exposure_time: f64,
 }
 
 #[async_trait]
@@ -19,23 +19,23 @@ pub trait PrintFile {
         Self: Sized;
     async fn get_layer_data(&mut self, index: usize) -> Option<Layer>;
     fn get_layer_count(&self) -> usize;
-    fn get_layer_height(&self) -> f32;
+    fn get_layer_height(&self) -> u32;
     fn get_metadata(&self) -> PrintMetadata;
     fn get_thumbnail(&mut self) -> Result<FileData, Error>;
     // Optional fields not present in every file type
-    fn get_lift(&self) -> Option<f32> {
+    fn get_lift(&self) -> Option<u32> {
         None
     }
-    fn get_up_speed(&self) -> Option<f32> {
+    fn get_up_speed(&self) -> Option<f64> {
         None
     }
-    fn get_down_speed(&self) -> Option<f32> {
+    fn get_down_speed(&self) -> Option<f64> {
         None
     }
-    fn get_wait_after_exposure(&self) -> Option<f32> {
+    fn get_wait_after_exposure(&self) -> Option<f64> {
         None
     }
-    fn get_wait_before_exposure(&self) -> Option<f32> {
+    fn get_wait_before_exposure(&self) -> Option<f64> {
         None
     }
 }

--- a/src/sl1.rs
+++ b/src/sl1.rs
@@ -24,31 +24,31 @@ const THUMBNAIL_FILE: &str = "thumbnail/thumbnail400x400.png";
 #[allow(dead_code)]
 pub struct PrintConfig {
     action: String,
-    exp_time: f32,
-    exp_time_first: f32,
+    exp_time: f64,
+    exp_time_first: f64,
     exp_user_profile: usize,
     file_creation_timestamp: String,
     hollow: usize,
     job_dir: String,
-    layer_height: f32,
+    layer_height: f64,
     material_name: String,
     num_fade: usize,
     num_fast: usize,
     num_slow: usize,
     print_profile: String,
-    print_time: f32,
+    print_time: f64,
     printer_model: String,
     printer_profile: String,
     printer_variant: String,
     prusa_slicer_version: String,
-    used_material: f32,
+    used_material: f64,
 }
 
 impl PrintConfig {
     /// Compute the exposure time of the given frame index, based on the PrintConfig
-    fn exposure_time(&self, index: usize) -> f32 {
+    fn exposure_time(&self, index: usize) -> f64 {
         if index < self.num_fade {
-            let fade_rate = (self.num_fade - index) as f32 / self.num_fade as f32;
+            let fade_rate = (self.num_fade - index) as f64 / self.num_fade as f64;
             self.exp_time + (self.exp_time_first - self.exp_time) * (fade_rate)
         } else {
             self.exp_time
@@ -107,6 +107,7 @@ impl PrintFile for Sl1 {
             used_material: config.used_material,
             print_time: config.print_time,
             layer_height: config.layer_height,
+            layer_height_microns: ((config.layer_height * 1000.0).trunc() as u32),
             layer_count: frame_list.len(),
         };
 
@@ -143,8 +144,8 @@ impl PrintFile for Sl1 {
         self.frame_list.len()
     }
 
-    fn get_layer_height(&self) -> f32 {
-        self.config.layer_height
+    fn get_layer_height(&self) -> u32 {
+        (self.config.layer_height * 1000.0).trunc() as u32
     }
 
     fn get_metadata(&self) -> PrintMetadata {


### PR DESCRIPTION
Swap internal distance values to microns, converted back to mm for
gcode output and additional API output
Preserve existing API fields, adding micron output as secondary option
Swap all float values read from config files to 64bit, following
serde's default read scheme and preventing any inaccuracies added by
downcasting