### PR TITLE
github_actions: swap pre-push check with pre-merge-commit 

### DIFF
--- a/.github/workflows/pre-merge-commit.yml
+++ b/.github/workflows/pre-merge-commit.yml
@@ -1,4 +1,4 @@
-name: Pre-Push Format Check
+name: pre-merge-commit Format Check
 
 
 on:
@@ -7,7 +7,7 @@ on:
     workflow_dispatch:
 
 jobs:
-    pre-push:
+    pre-merge-commit:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/src/api.rs
+++ b/src/api.rs
@@ -447,8 +447,7 @@ impl Api {
     ) -> Result<Json<PrintMetadata>> {
         let location = location.unwrap_or(LocationCategory::Local);
 
-        log::info!(
-            "Getting file metadata from {:?} in {:?}",
+        log::info!("Getting file metadata from {:?} in {:?}",
             file_path,
             location
         );

--- a/src/api.rs
+++ b/src/api.rs
@@ -447,7 +447,8 @@ impl Api {
     ) -> Result<Json<PrintMetadata>> {
         let location = location.unwrap_or(LocationCategory::Local);
 
-        log::info!("Getting file metadata from {:?} in {:?}",
+        log::info!(
+            "Getting file metadata from {:?} in {:?}",
             file_path,
             location
         );


### PR DESCRIPTION
Swap pre-push cargo fmt for pre-merge-commit to avoid slowing down
development quite so much